### PR TITLE
Add rosout topics to initial TO lab subscription table.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
 include_directories(${ci_lab_MISSION_DIR}/fsw/platform_inc)
 include_directories(${sample_app_MISSION_DIR}/fsw/platform_inc)
+include_directories(${ros_app_MISSION_DIR}/fsw/platform_inc)
 
 aux_source_directory(fsw/src APP_SRC_FILES)
 

--- a/fsw/tables/to_lab_sub.c
+++ b/fsw/tables/to_lab_sub.c
@@ -37,6 +37,7 @@
 #include "ci_lab_msgids.h"
 
 #include "sample_app_msgids.h"
+#include "ros_app_msgids.h"
 
 #if 0
 #include "hs_msgids.h"
@@ -51,6 +52,11 @@ TO_LAB_Subs_t TO_LAB_Subs = {.Subs = {/* CFS App Subscriptions */
                                       {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_DATA_TYPES_MID), {0, 0}, 4},
                                       {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_HK_TLM_MID), {0, 0}, 4},
                                       {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(ROS_APP_ROSOUT_DEBUG_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(ROS_APP_ROSOUT_INFO_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(ROS_APP_ROSOUT_WARN_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(ROS_APP_ROSOUT_ERROR_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(ROS_APP_ROSOUT_FATAL_MID), {0, 0}, 4},
 
 #if 0
         /* Add these if needed */


### PR DESCRIPTION
**Describe the contribution**
This basically adds ROSOUT MIDs to the default TO lab table so that they will come down in TO telemetry to the ground-side bridge.

**Testing performed**
Haven't tested this yet.

**Expected behavior changes**
Should start seeing ROSOUT MIDs coming down in TO.

**System(s) tested on**
Not tested yet.

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Andrew Harris